### PR TITLE
maybe solve the problem cant connect to MySQL

### DIFF
--- a/src/main/java/me/comphack/playerlogger/database/DatabaseManager.java
+++ b/src/main/java/me/comphack/playerlogger/database/DatabaseManager.java
@@ -161,7 +161,7 @@ public class DatabaseManager {
     }
 
     public void setJoinStats(String player, InetSocketAddress address, UUID uuid, LocalDate lastjoin) throws SQLException {
-        String SQL = "INSERT OR IGNORE INTO player_logs" +
+        String SQL = "INSERT IGNORE INTO player_logs" +
                 "(username, uuid, ip_address, last_join_date)" +
                 "VALUES ('" + player + "', '" + uuid + "', '" + address + "', '" + lastjoin + "');";
         if(isDebugMode()){


### PR DESCRIPTION
ChatGPT

Based on the provided error log, it appears that there is a syntax error in an SQL query being executed in the PlayerLogger plugin (version 1.1.2) for Bukkit/Spigot Minecraft servers. The error is occurring in the PlayerJoinEvent event handler.

The specific error message is:
```
java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'OR IGNORE INTO player_logs(username, uuid, ip_address, last_join_date)VALUES ('L' at line 1
```
The error is related to the SQL query that is attempting to be executed by the plugin to insert data into the player_logs table. The relevant part of the query causing the issue is:

```
INSERT OR IGNORE INTO player_logs(username, uuid, ip_address, last_join_date)VALUES ('L'...
```
The error message suggests that the SQL syntax near 'OR IGNORE INTO player_logs...' is incorrect, and the MySQL server is unable to parse it.

The OR IGNORE part of the query seems to be causing the problem. This part of the query is commonly used in SQLite to handle conflicts, but it is not a valid syntax in MySQL. If you intend to use MySQL, you should consider using INSERT IGNORE INTO instead.

To fix this issue, you should modify the query in the DatabaseManager.java file, specifically in the setJoinStats method. Change the query to use INSERT IGNORE INTO like this:
```
INSERT IGNORE INTO player_logs(username, uuid, ip_address, last_join_date) VALUES ('L'...
```
After making this change, recompile and redeploy the plugin to your Minecraft server. This should resolve the syntax error and allow the plugin to handle PlayerJoinEvent correctly without SQL syntax issues.